### PR TITLE
Enable reliable jobs using sidekiq options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ rdoc
 tmp
 *.swp
 *.rdb
+.idea

--- a/README.md
+++ b/README.md
@@ -74,10 +74,17 @@ After that you can use your jobs as usual.
 
 Specify desired configuration inside of `sidekiq.yml` file:
 
+By default jobs will not be monitored, in order to enable monitoring of your job, you will need to add `:
+attentive_reliable => true` sidekiq option it e.g.
+```ruby
+sidekiq_options :queue => :accessibility, :retry => 3, :attentive_reliable => true
+```
+
+
 ```YML
 attentive:
   # Time in seconds between checks for disappeared jobs
-  :execution_interval: 300  # default: 600
+  :execution_interval: 60  # default: 600
   # Time limit in seconds to perform disappeared jobs check
   :timeout_interval: 25     # default: 60
 ```

--- a/lib/attentive_sidekiq/api.rb
+++ b/lib/attentive_sidekiq/api.rb
@@ -26,7 +26,7 @@ module AttentiveSidekiq
   class Disappeared < RedisBasedHash
     STATUS_DETECTED = 'detected'
     STATUS_REQUEUED = 'requeued'
-    SIDEKIQ_PUSH_OPTIONS = %w[queue class args retry backtrace].freeze
+    SIDEKIQ_PUSH_OPTIONS = %w[queue class args retry backtrace attentive_reliable].freeze
 
     class << self
       alias_method :base_add, :add

--- a/lib/attentive_sidekiq/middleware/server/attentionist.rb
+++ b/lib/attentive_sidekiq/middleware/server/attentionist.rb
@@ -3,10 +3,16 @@ module AttentiveSidekiq
     module Server
       class Attentionist
         def call(worker_instance, item, queue)
-          Suspicious.add(item)
+          reliable_job = item["attentive_reliable"]
+
+          if reliable_job
+            AttentiveSidekiq.logger.info("AttentiveSidekiq will monitor job: #{item}")
+            Suspicious.add(item)
+          end
+
           yield
         ensure
-          Suspicious.remove(item['jid'])
+          Suspicious.remove(item['jid']) if reliable_job
         end
       end
     end


### PR DESCRIPTION
Only monitor jobs that specify the sidekiq option `:attentive_reliable => true`