### PR TITLE
Allow some time before doing the second check for suspicious jobs

### DIFF
--- a/lib/attentive_sidekiq/manager.rb
+++ b/lib/attentive_sidekiq/manager.rb
@@ -24,6 +24,10 @@ module AttentiveSidekiq
       # We need to get the new suspicious list again, and remove any lost jobs that are no longer there.
       # Those jobs that appeared in the first suspicious list, but not the second one were simply finished
       # quickly by Sidekiq before showing up as active by a worker.
+
+      # give sidekiq time to update suspicious list, maybe the jobs finished,
+      # but it takes some time until it is removed from the suspicious list
+      sleep(10)
       suspicious  = AttentiveSidekiq::Suspicious.jobs
       those_lost.delete_if{|i| !suspicious.any?{|j| i['jid'] == j['jid']} }
       


### PR DESCRIPTION
attentive-sidekiq offers a middleware that [adds to a suspicious list](https://github.com/sensortower/attentive_sidekiq/blob/28f7cf13ec34aacbf6971c9f4175b47f366a8562/lib/attentive_sidekiq/middleware/server/attentionist.rb#L10) each jobs when it starts and [removes it when it finishes](https://github.com/sensortower/attentive_sidekiq/blob/28f7cf13ec34aacbf6971c9f4175b47f366a8562/lib/attentive_sidekiq/middleware/server/attentionist.rb#L15). There can be a short interval when a job is not active, but it did not get removed from the suspicious list. 
If [a check](https://github.com/sensortower/attentive_sidekiq/blob/28f7cf13ec34aacbf6971c9f4175b47f366a8562/lib/attentive_sidekiq/manager.rb#L17) is done during this time, the jobs will get reported as disappeared (false positive).
Because there are many sidekiq jobs that all do the check (hundreds or thousands), there is a high chance that one of them catches this case