### PR TITLE
Remove jobs that are marked as disappeared if we can detect them

### DIFF
--- a/lib/attentive_sidekiq/middleware/server/attentionist.rb
+++ b/lib/attentive_sidekiq/middleware/server/attentionist.rb
@@ -12,7 +12,10 @@ module AttentiveSidekiq
 
           yield
         ensure
-          Suspicious.remove(item['jid']) if reliable_job
+          if reliable_job
+            Suspicious.remove(item['jid'])
+            Disappeared.remove(item['jid'])
+          end
         end
       end
     end


### PR DESCRIPTION
Remove jobs that are marked as disappeared if they are detected by the middleware.